### PR TITLE
chore: removed unused import

### DIFF
--- a/manager/consumers.py
+++ b/manager/consumers.py
@@ -1,14 +1,12 @@
 import asyncio
 import json
 import logging
-
 from asgiref.sync import sync_to_async
 from channels.generic.websocket import AsyncWebsocketConsumer
 from django.apps import apps
 
-from participant.models import Participant
-
 logger = logging.getLogger('queue')
+
 
 class QueueDisplayConsumer(AsyncWebsocketConsumer):
     async def connect(self):

--- a/participant/consumers.py
+++ b/participant/consumers.py
@@ -2,7 +2,7 @@ import json
 import asyncio
 from asgiref.sync import sync_to_async
 from channels.generic.websocket import AsyncWebsocketConsumer
-from django.apps import apps  # Import for lazy model loading
+from django.apps import apps
 from django.utils import timezone
 import logging
 


### PR DESCRIPTION
- Removed global import in consumers.py that caused circular import error in deployment.